### PR TITLE
SSL: Add optional custom extension parsing.

### DIFF
--- a/src/core/nginx.h
+++ b/src/core/nginx.h
@@ -9,8 +9,8 @@
 #define _NGINX_H_INCLUDED_
 
 
-#define nginx_version      1027002
-#define NGINX_VERSION      "1.27.2"
+#define nginx_version      1027003
+#define NGINX_VERSION      "1.27.3"
 #define NGINX_VER          "nginx/" NGINX_VERSION
 
 #ifdef NGX_BUILD

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -135,6 +135,15 @@ int  ngx_ssl_certificate_index;
 int  ngx_ssl_next_certificate_index;
 int  ngx_ssl_certificate_name_index;
 int  ngx_ssl_stapling_index;
+int  ngx_ssl_custom_extension_index;
+
+
+void free_custom_extension_data(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx, long argl, void *argp) {
+    char *extension_data = (char *)ptr;
+    if (extension_data) {
+        free(extension_data);
+    }
+}
 
 
 ngx_int_t
@@ -219,6 +228,13 @@ ngx_ssl_init(ngx_log_t *log)
     }
     }
 #endif
+
+    ngx_ssl_custom_extension_index = SSL_get_ex_new_index(0, NULL, NULL, NULL, free_custom_extension_data);
+
+    if (ngx_ssl_custom_extension_index == -1) {
+        ngx_ssl_error(NGX_LOG_ALERT, log, 0, "SSL_get_ex_new_index() failed");
+        return NGX_ERROR;
+    }
 
     ngx_ssl_connection_index = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
 
@@ -5034,7 +5050,6 @@ ngx_ssl_check_name(ngx_str_t *name, ASN1_STRING *pattern)
 #endif
 
 
-
 ngx_int_t
 ngx_ssl_get_custom_extension(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 {    
@@ -5044,7 +5059,7 @@ ngx_ssl_get_custom_extension(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s
     }
 
     const char * extension_data;
-    extension_data = (const char *)SSL_get_ex_data(ssl, 0);
+    extension_data = (const char *)SSL_get_ex_data(ssl, ngx_ssl_custom_extension_index);
     if (extension_data == NULL){
         extension_data = "";
     }

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -5034,6 +5034,27 @@ ngx_ssl_check_name(ngx_str_t *name, ASN1_STRING *pattern)
 #endif
 
 
+
+ngx_int_t
+ngx_ssl_get_custom_extension(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+{    
+    SSL *ssl = c->ssl->connection;
+    if (ssl == NULL) {
+        return NGX_ERROR;
+    }
+
+    const char * extension_data;
+    extension_data = (const char *)SSL_get_ex_data(ssl, 0);
+    if (extension_data == NULL){
+        extension_data = "";
+    }
+    s->data = (u_char *)extension_data;
+    s->len = strlen(extension_data);
+
+    return NGX_OK;
+}
+
+
 ngx_int_t
 ngx_ssl_get_protocol(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 {

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -260,7 +260,8 @@ ngx_ssl_session_t *ngx_ssl_get0_session(ngx_connection_t *c);
 
 ngx_int_t ngx_ssl_check_host(ngx_connection_t *c, ngx_str_t *name);
 
-
+ngx_int_t ngx_ssl_get_custom_extension(ngx_connection_t *c, ngx_pool_t *pool,
+    ngx_str_t *s);
 ngx_int_t ngx_ssl_get_protocol(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_cipher_name(ngx_connection_t *c, ngx_pool_t *pool,

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -260,6 +260,7 @@ ngx_ssl_session_t *ngx_ssl_get0_session(ngx_connection_t *c);
 
 ngx_int_t ngx_ssl_check_host(ngx_connection_t *c, ngx_str_t *name);
 
+
 ngx_int_t ngx_ssl_get_custom_extension(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_protocol(ngx_connection_t *c, ngx_pool_t *pool,
@@ -335,6 +336,7 @@ extern int  ngx_ssl_certificate_index;
 extern int  ngx_ssl_next_certificate_index;
 extern int  ngx_ssl_certificate_name_index;
 extern int  ngx_ssl_stapling_index;
+extern int  ngx_ssl_custom_extension_index;
 
 
 #endif /* _NGX_EVENT_OPENSSL_H_INCLUDED_ */

--- a/src/event/quic/ngx_event_quic_ack.c
+++ b/src/event/quic/ngx_event_quic_ack.c
@@ -631,13 +631,12 @@ ngx_quic_resend_frames(ngx_connection_t *c, ngx_quic_send_ctx_t *ctx)
         case NGX_QUIC_FT_STREAM:
             qs = ngx_quic_find_stream(&qc->streams.tree, f->u.stream.stream_id);
 
-            if (qs) {
-                if (qs->send_state == NGX_QUIC_STREAM_SEND_RESET_SENT
-                    || qs->send_state == NGX_QUIC_STREAM_SEND_RESET_RECVD)
-                {
-                    ngx_quic_free_frame(c, f);
-                    break;
-                }
+            if (qs == NULL
+                || qs->send_state == NGX_QUIC_STREAM_SEND_RESET_SENT
+                || qs->send_state == NGX_QUIC_STREAM_SEND_RESET_RECVD)
+            {
+                ngx_quic_free_frame(c, f);
+                break;
             }
 
             /* fall through */

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -36,6 +36,8 @@ static ngx_int_t ngx_http_ssl_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 
 static ngx_int_t ngx_http_ssl_add_variables(ngx_conf_t *cf);
+static ngx_int_t ngx_http_ssl_add_variable(ngx_conf_t *cf, ngx_http_variable_t  *v);
+
 static void *ngx_http_ssl_create_srv_conf(ngx_conf_t *cf);
 static char *ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf,
     void *parent, void *child);
@@ -43,6 +45,7 @@ static char *ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf,
 static ngx_int_t ngx_http_ssl_compile_certificates(ngx_conf_t *cf,
     ngx_http_ssl_srv_conf_t *conf);
 
+static char *ngx_conf_set_custom_extension(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *ngx_http_ssl_password_file(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 static char *ngx_http_ssl_session_cache(ngx_conf_t *cf, ngx_command_t *cmd,
@@ -288,6 +291,13 @@ static ngx_command_t  ngx_http_ssl_commands[] = {
       ngx_conf_set_flag_slot,
       NGX_HTTP_SRV_CONF_OFFSET,
       offsetof(ngx_http_ssl_srv_conf_t, reject_handshake),
+      NULL },
+
+    { ngx_string("ssl_custom_extension"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE2,
+      ngx_conf_set_custom_extension,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_ssl_srv_conf_t, custom_extension_type),
       NULL },
 
       ngx_null_command
@@ -584,6 +594,23 @@ ngx_http_ssl_add_variables(ngx_conf_t *cf)
 }
 
 
+static ngx_int_t
+ngx_http_ssl_add_variable(ngx_conf_t *cf, ngx_http_variable_t  *v)
+{
+    ngx_http_variable_t  *var;
+
+    var = ngx_http_add_variable(cf, &v->name, v->flags);
+    if (var == NULL) {
+        return NGX_ERROR;
+    }
+
+    var->get_handler = v->get_handler;
+    var->data = v->data;
+
+    return NGX_OK;
+}
+
+
 static void *
 ngx_http_ssl_create_srv_conf(ngx_conf_t *cf)
 {
@@ -629,10 +656,26 @@ ngx_http_ssl_create_srv_conf(ngx_conf_t *cf)
     sscf->ocsp_cache_zone = NGX_CONF_UNSET_PTR;
     sscf->stapling = NGX_CONF_UNSET;
     sscf->stapling_verify = NGX_CONF_UNSET;
+    sscf->custom_extension_type = NGX_CONF_UNSET_UINT;
 
     return sscf;
 }
 
+/* Callback to parse the custom extension data */
+int parse_custom_extension_callback(SSL *ssl, unsigned int ext_type, unsigned int context,
+                        const unsigned char *in, size_t inlen, X509 *x,
+                        size_t chainidx, int *al, void *parse_arg) {
+
+    char *extension_data = malloc(inlen + 1);
+    if (extension_data == NULL) {
+        return 0;
+    }
+    memcpy(extension_data, in, inlen);
+    extension_data[inlen] = '\0';
+
+    SSL_set_ex_data(ssl, 0, extension_data);
+    return 1;
+}
 
 static char *
 ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
@@ -725,6 +768,19 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     cln->handler = ngx_ssl_cleanup_ctx;
     cln->data = &conf->ssl;
+  
+    if(conf->custom_extension_type != NGX_CONF_UNSET_UINT){
+        SSL_CTX_add_custom_ext(
+            conf->ssl.ctx,
+            conf->custom_extension_type,
+            SSL_EXT_CLIENT_HELLO,
+            NULL,
+            NULL,
+            NULL,
+            parse_custom_extension_callback,
+            NULL
+        );
+    }
 
 #ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
 
@@ -979,6 +1035,42 @@ found:
     }
 
     return NGX_OK;
+}
+
+
+static char *
+ngx_conf_set_custom_extension(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    char  *p = conf;
+    ngx_int_t   *extension_type;
+    ngx_str_t   var_name, *value;
+
+    extension_type = (ngx_int_t *) (p + cmd->offset);
+    
+    if (*extension_type != NGX_CONF_UNSET) {
+        return "is duplicate";
+    }
+
+    value = cf->args->elts;
+
+    *extension_type = ngx_atoi(value[1].data, value[1].len);
+    if (*extension_type == NGX_ERROR) {
+        return "invalid number";
+    }
+
+    var_name = value[2];
+
+    ngx_http_variable_t  var = { 
+        var_name,
+        NULL,
+        ngx_http_ssl_variable,
+        (uintptr_t) ngx_ssl_get_custom_extension,
+        NGX_HTTP_VAR_CHANGEABLE,
+        0
+    };
+    ngx_http_ssl_add_variable(cf, &var);
+
+    return NGX_CONF_OK;
 }
 
 

--- a/src/http/modules/ngx_http_ssl_module.h
+++ b/src/http/modules/ngx_http_ssl_module.h
@@ -62,6 +62,7 @@ typedef struct {
     ngx_flag_t                      stapling_verify;
     ngx_str_t                       stapling_file;
     ngx_str_t                       stapling_responder;
+    ngx_uint_t                      custom_extension_type;
 } ngx_http_ssl_srv_conf_t;
 
 


### PR DESCRIPTION
Add SSL command for extract TLS custom extension and use as variable in nginx.conf
```
ssl_custom_extension <custom-extension-type> <variable-name>
```

then client send TLS request with extension , nginx parse value of extension into variable name then use variable in nginx config

Example:
nginx.conf
```
http {
  server {
    listen 443 ssl;
    server_name _;

    ssl_certificate server.crt;
    ssl_certificate_key server.key;
    ssl_custom_extension 1000 custom_extenstion;

    location / {
      add_header X-tls-custom-extension $custom_extenstion;

      root        /usr/local/nginx/html/;
      index       index.html;
    }
  }
}
```

Request
```
Extension: Unknown type 1000 (len=7)
    Type: Unknown (1000)
    Length: 7
    Data: Soroush
```

Response
```
Bytes: 361                                                                                              
Received: HTTP/1.1 200 OK                                                                               
Server: nginx/1.27.2                                                                                    
Date: Sat, 14 Sep 2024 11:26:18 GMT                                                                     
Content-Type: text/html                                                                                 
Content-Length: 97                                                                                     
Last-Modified: Sun, 01 Sep 2024 06:40:46 GMT                                                           
Connection: close                                                                                     
ETag: "66d40c6e-61"                                                                                   
X-tls-custom-extension: Soroush                                                                    
Accept-Ranges: bytes 
```